### PR TITLE
Remove year from RSS feed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
   <meta name="keywords" content="HTML,CSS,JavaScript,web,PWA,tutorials,code,tweets">
   <meta name="author" content="Eric Bidelman">
   <meta name="google-site-verification" content="j4g2UAPd-Fnxh2o_daravb8lvXwZuatJt5kVSbdM0Fc" />
-  <link rel="alternate" type="application/rss+xml" href="https://devwebfeed.appspot.com/posts/2018?format=rss" title="DevWeb Firehose RSS feed">
+  <link rel="alternate" type="application/rss+xml" href="https://devwebfeed.appspot.com/posts/?format=rss" title="DevWeb Firehose RSS feed">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" sizes="192x192" href="img/firehose.png">
   <link rel="shortcut icon" href="img/firehose.png">
@@ -52,7 +52,7 @@
         <a href="#" onclick="return toggleHelp()" class="layout">
           <img src="img/help_24px.svg" height="18" width="18" class="helpicon" title="Help" alt="Help">
         </a>
-        <a href="https://devwebfeed.appspot.com/posts/2018?format=rss" target="_blank" class="layout">
+        <a href="https://devwebfeed.appspot.com/posts/?format=rss" target="_blank" class="layout">
           <img src="img/rss_icon_24px_orange.svg" width="18" height="18" class="rssicon"  title="Subscribe to RSS feed" alt="Subscribe to RSS feed">
         </a>
       </h4>


### PR DESCRIPTION
No need for the year, https://devwebfeed.appspot.com/posts/?format=rss just works, and is self-referenced in the feed already:

```xml
<atom:link href="http://devwebfeed.appspot.com/posts/?format=rss" rel="self" type="application/rss+xml"/>
```